### PR TITLE
AI상담 -> 오늘의 식단 추천 관련 리메이크

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
         "@types/jsonwebtoken": "^9.0.7",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.4.6",
         "express": "^4.21.1",
         "jsonwebtoken": "^9.0.2",

--- a/src/api/openAi.ts
+++ b/src/api/openAi.ts
@@ -14,10 +14,52 @@ export async function callOpenAIAPI(prompt: string): Promise<string | null> {
             messages: [
                 {
                     role: "system",
-                    content:
-                        "Your role is a personalized fitness trainer." +
-                        " From now on, you should check and advise me on my physical information," +
-                        " activity information, and target. Please answer in Korean",
+                    content: `
+                    You are a personalized fitness trainer AI.  
+                    Based on the user's profile, recommend today’s diet and workout.
+                    
+                    Guidelines:
+                    - Base the diet recommendations on common Korean meals and ingredients.
+                    - Make sure the suggestions are culturally appropriate for Korean users.
+
+                    For workouts, recommend realistic home or outdoor exercises suitable for Korean users (e.g. apartment-friendly, gym-less options).
+
+                    Respond ONLY with valid JSON.  
+                    DO NOT include any explanation, greetings, or extra text.  
+                    The JSON values (diet/workout items) MUST be written in Korean.
+                    
+                    JSON format example:
+                    {
+                    "diet": [
+                    {
+                        "meal": "아침: 현미밥, 미역국, 계란찜",
+                        "calories": 420,
+                        "carbs": 55,
+                        "protein": 20,
+                        "fat": 12
+                    },
+                    {
+                        "meal": "점심: 보리밥, 불고기, 배추김치",
+                        "calories": 610,
+                        "carbs": 65,
+                        "protein": 35,
+                        "fat": 20
+                    },
+                    {
+                        "meal": "저녁: 고구마, 닭가슴살, 샐러드",
+                        "calories": 500,
+                        "carbs": 45,
+                        "protein": 40,
+                        "fat": 10
+                    }
+                    ],
+                    "workout": [
+                    "스트레칭 10분",
+                    "스쿼트 3세트",
+                    "실내 유산소 운동 15분"
+                    ]
+                }
+                    `.trim(),
                 },
                 {
                     role: "user",

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,15 +11,22 @@ import {
     signupHandler,
 } from "./service/auth";
 import {
+    checkProfileByTokenHandler,
     checkProfileHandler,
     generateSupportHandler,
     saveProfileHandler,
 } from "./service/support";
 import {
+    mypageChartHandler,
     mypageProfileHandler,
     mypageSaveProfileHandler,
     mypagehistoryHandler,
 } from "./service/mypage";
+import {
+    checkDietLogHandler,
+    getUserDiet,
+    clearDietLogHandler,
+} from "./service/diet";
 
 dotenv.config();
 
@@ -44,11 +51,17 @@ app.post("/auth/refresh", refreshTokenHandler);
 app.post("/auth/logout", logoutHandler);
 app.post("/kakao/token", kakaoTokenHandler);
 
+app.get("/diet/check", getUserDiet);
+app.post("/diet/log", checkDietLogHandler);
+app.delete("/diet/log", clearDietLogHandler);
+
 app.get("/profile/check", checkProfileHandler);
+app.get("/profile/token", checkProfileByTokenHandler);
 app.post("/profile/save", saveProfileHandler);
 app.post("/generate/support", generateSupportHandler);
 
 app.get("/mypage/profile", mypageProfileHandler);
+app.get("/mypage/chart", mypageChartHandler);
 app.get("/mypage/history", mypagehistoryHandler);
 app.post("/mypage/save", mypageSaveProfileHandler);
 

--- a/src/service/auth.ts
+++ b/src/service/auth.ts
@@ -68,12 +68,24 @@ export async function loginHandler(req: Request, res: any) {
                 await updateResultWithToken(user.id, token);
             await updateProfileWithToken(user.id, token);
 
+            await getUserProfileById(user.id);
+            await getUserProfileById(user.id);
+
+            const userProfile: UserProfile | null = await getUserProfileById(
+                user.id
+            );
+
             return res.status(200).json({
                 success: true,
                 message: updateResultMessage,
-                data: { accessToken: accessToken, user: user },
+                data: {
+                    accessToken: accessToken,
+                    user: user,
+                    userProfile: userProfile,
+                },
             });
         }
+
         const userProfile: UserProfile | null = await getUserProfileById(
             user.id
         );

--- a/src/service/diet.ts
+++ b/src/service/diet.ts
@@ -1,0 +1,160 @@
+import mysql from "mysql2/promise";
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { connectPool } from "./db";
+import { Request } from "express";
+import { verifyAccessToken } from "../utils/jwt";
+import { AIResponse, CheckedMeal, Meal } from "../structure/type";
+
+export async function checkDietLogHandler(req: Request, res: any) {
+    try {
+        const {
+            meal,
+            date,
+            checked,
+        }: { meal: string; date: string; checked: boolean } = req.body;
+        const user: JwtPayload | null = verifyAccessToken(
+            req.headers.authorization
+        );
+
+        if (user == null) {
+            return res.status(401).json({
+                success: false,
+                message: "Unauthenticated user.",
+            });
+        }
+
+        const userInfo = user as { id: number; nickname: string };
+
+        const [result] = await connectPool.query<mysql.RowDataPacket[]>(
+            "SELECT `id` FROM `result` WHERE `user_id` = ? ORDER BY `created_at` DESC LIMIT 1",
+            [userInfo.id]
+        );
+
+        const resultId = result[0]?.id ?? null;
+
+        if (resultId == null) {
+            return res.status(500).json({
+                success: false,
+                error: "result information not found.",
+            });
+        }
+
+        const [save] = await connectPool.query<mysql.ResultSetHeader>(
+            "UPDATE diet_logs SET checked = ? WHERE user_id = ? AND meal = ? AND date = ? AND result_id = ?",
+            [checked, user.id, meal, date, resultId]
+        );
+
+        return res.status(200).json({
+            success: true,
+            data: {
+                insertedId: save.insertId,
+            },
+        });
+    } catch (error) {
+        console.error("❌ 식단 저장 실패:", error);
+        return res.status(500).json({
+            success: false,
+            message: "diet failed to create.",
+        });
+    }
+}
+
+export async function clearDietLogHandler(req: Request, res: any) {
+    try {
+        const {
+            date,
+            resultId,
+        }: {
+            date: string;
+            resultId: number;
+        } = req.body;
+
+        const user = verifyAccessToken(req.headers.authorization);
+
+        if (user == null) {
+            return res.status(401).json({
+                success: false,
+                message: "Unauthenticated user.",
+            });
+        }
+
+        const userInfo = user as { id: number; nickname: string };
+
+        const [result] = await connectPool.query<mysql.ResultSetHeader>(
+            "DELETE FROM `diet_logs` WHERE `user_id` = ? AND `date` = ? AND `result_id` = ?",
+            [userInfo.id, date, resultId]
+        );
+
+        return res.status(200).json({
+            success: true,
+            affectedRows: result.affectedRows,
+            message:
+                result.affectedRows > 0
+                    ? "삭제 완료"
+                    : "삭제할 데이터가 없습니다",
+        });
+    } catch (error) {
+        console.error("❌ 식단 삭제 실패:", error);
+        return res.status(500).json({
+            success: false,
+            error: "diet failed to delete",
+        });
+    }
+}
+
+export async function getUserDiet(req: Request, res: any) {
+    const user: JwtPayload | null = verifyAccessToken(
+        req.headers.authorization
+    );
+
+    if (user == null) {
+        return res.status(500).json({
+            success: false,
+            error: "user information not found.",
+        });
+    }
+
+    const userInfo = user as { id: number; nickname: string };
+
+    const [result] = await connectPool.query<mysql.RowDataPacket[]>(
+        "SELECT `id`, `content`" +
+            "FROM `result` " +
+            "WHERE `user_id` = ? " +
+            "AND DATE(CONVERT_TZ(`created_at`, '+00:00', '+09:00')) = CURDATE() " +
+            "ORDER BY `created_at` DESC " +
+            "LIMIT 1",
+        [userInfo.id]
+    );
+
+    // 결과가 없을수도 있으니 에러 처리가 아니라 null값을 내려줘야함
+    if (result.length == 0) {
+        return res.status(200).json({
+            success: true,
+            data: null,
+        });
+    }
+
+    const resultId: number = result[0].id;
+    const content: AIResponse = JSON.parse(result[0]?.content) ?? null;
+
+    const [logs] = await connectPool.query<mysql.RowDataPacket[]>(
+        "SELECT `meal`, `checked` FROM `diet_logs` WHERE `user_id` = ? AND `result_id` = ?",
+        [userInfo.id, resultId]
+    );
+
+    const checkedMap = new Map(logs.map((log) => [log.meal, log.checked]));
+
+    const enrichedDiet: CheckedMeal[] = content.diet.map((item: Meal) => ({
+        ...item,
+        checked: !!checkedMap.get(item.meal),
+    }));
+
+    return res.status(200).json({
+        success: true,
+        data: {
+            diet: enrichedDiet,
+            workout: content.workout,
+            resultId: resultId,
+        },
+    });
+}

--- a/src/service/mypage.ts
+++ b/src/service/mypage.ts
@@ -1,8 +1,10 @@
 import mysql from "mysql2/promise";
+import dayjs from "dayjs";
 import { connectPool } from "./db";
 import { Request } from "express";
 import { JwtPayload } from "jsonwebtoken";
 import { verifyAccessToken } from "../utils/jwt";
+import { getKoreanWeekDates } from "../utils/day";
 
 export async function mypageProfileHandler(req: Request, res: any) {
     const user: JwtPayload | null = verifyAccessToken(
@@ -47,23 +49,23 @@ export async function mypageProfileHandler(req: Request, res: any) {
 
 export async function mypageSaveProfileHandler(req: Request, res: any) {
     try {
-        const user: JwtPayload | null = verifyAccessToken(
-            req.headers.authorization
-        );
-
         const { weight } = req.body;
-
-        if (user == null) {
-            return res.status(400).json({
-                success: false,
-                error: "Invalid access token",
-            });
-        }
 
         if (weight == null) {
             return res.status(400).json({
                 success: false,
                 error: "Invalid weight info",
+            });
+        }
+
+        const user: JwtPayload | null = verifyAccessToken(
+            req.headers.authorization
+        );
+
+        if (user == null) {
+            return res.status(400).json({
+                success: false,
+                error: "Invalid access token",
             });
         }
 
@@ -116,6 +118,61 @@ export async function mypageSaveProfileHandler(req: Request, res: any) {
             error: "Internal server error",
         });
     }
+}
+
+export async function mypageChartHandler(req: Request, res: any) {
+    const user: JwtPayload | null = verifyAccessToken(
+        req.headers.authorization
+    );
+
+    if (user == null) {
+        return res.status(400).json({
+            success: false,
+            error: "Invalid access token",
+        });
+    }
+
+    const userInfo = user as { id: number; nickname: string };
+
+    const weekDates: string[] = getKoreanWeekDates();
+
+    const startDate: string = weekDates[0];
+    const endDate: string = weekDates[6];
+
+    const [logs] = await connectPool.query<mysql.RowDataPacket[]>(
+        `SELECT 
+            DATE(date) as date,
+            COUNT(*) as total,
+            SUM(CASE WHEN checked = 1 THEN 1 ELSE 0 END) as completed
+        FROM diet_logs
+        WHERE user_id = ? AND date BETWEEN ? AND ?
+        GROUP BY DATE(date)
+        ORDER BY DATE(date)`,
+        [userInfo.id, startDate, endDate]
+    );
+
+    const formattedLogs = logs.map((log) => ({
+        ...log,
+        date: dayjs(log.date).format("YYYY-MM-DD"),
+        total: Number(log.total),
+        completed: Number(log.completed),
+    }));
+
+    const logsMap = new Map(formattedLogs.map((log) => [log.date, log]));
+
+    const weekStats = weekDates.map((date) => {
+        const dayLog = logsMap.get(date);
+        const total = dayLog?.total ?? 0;
+        const completed = dayLog?.completed ?? 0;
+        const rate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+        return { date, total, completed, rate };
+    });
+
+    return res.status(200).json({
+        success: true,
+        data: weekStats,
+    });
 }
 
 export async function mypagehistoryHandler(req: Request, res: any) {

--- a/src/service/mypage.ts
+++ b/src/service/mypage.ts
@@ -134,7 +134,7 @@ export async function mypagehistoryHandler(req: Request, res: any) {
 
     try {
         const [result] = await connectPool.query<mysql.RowDataPacket[]>(
-            "SELECT `question`, `content`, `created_at` FROM `result` WHERE `user_id` = ? ORDER BY `created_at` DESC LIMIT 5",
+            "SELECT `content`, `created_at` FROM `result` WHERE `user_id` = ? ORDER BY `created_at` DESC LIMIT 5",
             [userInfo.id]
         );
 

--- a/src/structure/type.ts
+++ b/src/structure/type.ts
@@ -32,3 +32,25 @@ export interface UserProfile {
     activityLevel: string;
     target: string;
 }
+
+export interface Meal {
+    meal: string;
+    calories: number;
+    carbs: number;
+    protein: number;
+    fat: number;
+}
+
+export interface CheckedMeal extends Meal {
+    checked: boolean;
+}
+
+export interface AIResponse {
+    diet: Meal[];
+    workout: string[];
+}
+
+export interface WeekDay {
+    date: string;
+    label: string;
+}

--- a/src/utils/day.ts
+++ b/src/utils/day.ts
@@ -1,0 +1,33 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import isoWeek from "dayjs/plugin/isoWeek";
+
+// 시간대 추가
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(isoWeek);
+
+export function getWeekDates(): string[] {
+    const today = dayjs();
+
+    const monday = today.startOf("isoWeek"); // 월요일
+    const week = [];
+
+    for (let i = 0; i < 7; i++) {
+        week.push(monday.add(i, "day").format("YYYY-MM-DD"));
+    }
+
+    return week;
+}
+
+export function getKoreanWeekDates(): string[] {
+    const monday = dayjs().tz("Asia/Seoul").startOf("isoWeek");
+    const week: string[] = [];
+
+    for (let i = 0; i < 7; i++) {
+        week.push(monday.add(i, "day").format("YYYY-MM-DD"));
+    }
+
+    return week;
+}

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -9,7 +9,7 @@ export async function updateResultWithToken(id: number, token: string) {
         );
 
         if (save.affectedRows > 0) {
-            return "상담 결과가 저장되었습니다.";
+            return "결과가 저장되었습니다.";
         } else {
             return null;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,6 +361,11 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
이번 PR은 AI상담기능을 오늘의 식단 추천 및 식단 체크 로직을 추가하는 PR입니다.

## 변경사항
### auth
- 로그인시 유저 프로필 정보 내려주도록 수정
### utils/day
- dayjs 추가
- day관련 로직 추가
### support
- 결과 저장시 result테이블과 diet_logs테이블에 같이 저장되도록 수정
- diet_logs에 식단별 저장되도록 로직 구현
### mypage
- 마이페이지 주간 식단 이행률 관련 로직 추가
### diet
- 식단 체크, 삭제 관련 로직 추가
### server.ts
- API 주소 연결